### PR TITLE
Add BuildingServiceTools project

### DIFF
--- a/BuildingServiceTools/README.md
+++ b/BuildingServiceTools/README.md
@@ -1,0 +1,15 @@
+# BuildingServiceTools
+
+This project provides tools for calculating Canadian Electrical Code (CEC) 2024 service-load requirements for residential buildings. It includes calculators for individual houses and duplexes with a simple graphical user interface.
+
+## Requirements
+- Python 3.10 or newer
+- Only the Python standard library is used
+
+## Usage
+Run the GUI application:
+```bash
+python -m cec_service.gui.app
+```
+
+The calculators can also be used programmatically through the `cec_service` package.

--- a/BuildingServiceTools/cec_service/__init__.py
+++ b/BuildingServiceTools/cec_service/__init__.py
@@ -1,0 +1,5 @@
+"""CEC service calculation package."""
+from importlib import metadata
+
+__all__ = ["__version__"]
+__version__ = metadata.version("BuildingServiceTools")

--- a/BuildingServiceTools/cec_service/calculators/duplex.py
+++ b/BuildingServiceTools/cec_service/calculators/duplex.py
@@ -1,0 +1,45 @@
+"""Duplex service load calculator."""
+from dataclasses import asdict
+from math import ceil
+
+from ..models import Dwelling
+from ..utils.breakers import next_standard_breaker
+
+
+def _unit_loads(dw: Dwelling) -> tuple[int, int]:
+    """Return tuple of (base_watts_without_heat_ac, heat_ac_watts)."""
+    basic_load = 5000
+    if dw.floor_area_m2 > 90:
+        extra_area = dw.floor_area_m2 - 90
+        basic_load += ceil(extra_area / 90) * 1000
+
+    range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
+    ev_load = dw.ev_amps * 240 if dw.has_ev else 0
+    dryer_load = int((dw.dryer_kw or 0) * 1000 * 0.25)
+    wh_load = int((dw.water_heater_kw or 0) * 1000 * 0.25)
+    heat_ac = max(dw.heat_kw or 0, dw.ac_kw or 0) * 1000
+
+    base = basic_load + range_load + ev_load + dryer_load + wh_load
+    return base, int(heat_ac)
+
+
+def calculate_duplex_demand(a: Dwelling, b: Dwelling) -> dict:
+    """Calculate service demand for a duplex."""
+    base_a, heat_a = _unit_loads(a)
+    base_b, heat_b = _unit_loads(b)
+
+    if base_a >= base_b:
+        total = base_a + int(base_b * 0.65)
+    else:
+        total = base_b + int(base_a * 0.65)
+
+    total += heat_a + heat_b
+    amps = total / 240
+    breaker = next_standard_breaker(amps)
+
+    return {
+        "watts": total,
+        "amps": amps,
+        "suggested_breaker": breaker,
+        "inputs": {"unit_a": asdict(a), "unit_b": asdict(b)},
+    }

--- a/BuildingServiceTools/cec_service/calculators/house.py
+++ b/BuildingServiceTools/cec_service/calculators/house.py
@@ -1,0 +1,31 @@
+"""House service load calculator."""
+from dataclasses import asdict
+from math import ceil
+
+from ..models import Dwelling
+from ..utils.breakers import next_standard_breaker
+
+
+def calculate_demand(dw: Dwelling) -> dict:
+    """Calculate service demand for a single dwelling unit."""
+    basic_load = 5000
+    if dw.floor_area_m2 > 90:
+        extra_area = dw.floor_area_m2 - 90
+        basic_load += ceil(extra_area / 90) * 1000
+
+    heat_ac = max(dw.heat_kw or 0, dw.ac_kw or 0) * 1000
+    range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
+    ev_load = dw.ev_amps * 240 if dw.has_ev else 0
+    dryer_load = int((dw.dryer_kw or 0) * 1000 * 0.25)
+    wh_load = int((dw.water_heater_kw or 0) * 1000 * 0.25)
+
+    total_watts = basic_load + heat_ac + range_load + ev_load + dryer_load + wh_load
+    amps = total_watts / 240
+    breaker = next_standard_breaker(amps)
+
+    return {
+        "watts": total_watts,
+        "amps": amps,
+        "suggested_breaker": breaker,
+        "inputs": asdict(dw),
+    }

--- a/BuildingServiceTools/cec_service/gui/app.py
+++ b/BuildingServiceTools/cec_service/gui/app.py
@@ -1,0 +1,155 @@
+"""Tkinter GUI application for service calculations."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox, ttk
+
+from ..calculators.duplex import calculate_duplex_demand
+from ..calculators.house import calculate_demand
+from ..models import Dwelling
+from ..utils.validation import ValidationError, pos_or_none
+
+
+def _float_from_entry(entry: ttk.Entry) -> float | None:
+    text = entry.get().strip()
+    return float(text) if text else None
+
+
+class ServiceApp(tk.Tk):
+    """Main application window."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("CEC Service Calculator")
+        notebook = ttk.Notebook(self)
+        notebook.pack(fill="both", expand=True)
+
+        self._init_house_tab(notebook)
+        self._init_duplex_tab(notebook)
+
+    # House Tab
+    def _init_house_tab(self, notebook: ttk.Notebook) -> None:
+        frame = ttk.Frame(notebook)
+        notebook.add(frame, text="House")
+
+        labels = [
+            ("Floor Area (m²)", "floor"),
+            ("Heating kW", "heat"),
+            ("AC kW", "ac"),
+            ("Range kW", "range"),
+            ("Dryer kW", "dryer"),
+            ("Water Heater kW", "wh"),
+            ("EV Amps", "ev"),
+        ]
+        self.house_entries: dict[str, ttk.Entry] = {}
+        for row, (label, key) in enumerate(labels):
+            ttk.Label(frame, text=label).grid(row=row, column=0, sticky="w")
+            entry = ttk.Entry(frame)
+            entry.grid(row=row, column=1)
+            self.house_entries[key] = entry
+
+        self.house_ev_var = tk.BooleanVar()
+        ttk.Checkbutton(frame, text="Include EVSE", variable=self.house_ev_var).grid(
+            row=len(labels), column=0, columnspan=2
+        )
+
+        ttk.Button(frame, text="Calculate", command=self._calc_house).grid(
+            row=len(labels) + 1, column=0, columnspan=2, pady=5
+        )
+
+        self.house_result = tk.StringVar()
+        ttk.Label(frame, textvariable=self.house_result).grid(
+            row=len(labels) + 2, column=0, columnspan=2
+        )
+
+    def _calc_house(self) -> None:
+        try:
+            dw = Dwelling(
+                floor_area_m2=float(self.house_entries["floor"].get()),
+                heat_kw=pos_or_none(
+                    _float_from_entry(self.house_entries["heat"]), "heat_kw"
+                ),
+                ac_kw=pos_or_none(_float_from_entry(self.house_entries["ac"]), "ac_kw"),
+                range_kw=_float_from_entry(self.house_entries["range"]) or 12.0,
+                dryer_kw=pos_or_none(
+                    _float_from_entry(self.house_entries["dryer"]), "dryer_kw"
+                ),
+                water_heater_kw=pos_or_none(
+                    _float_from_entry(self.house_entries["wh"]), "water_heater_kw"
+                ),
+                has_ev=self.house_ev_var.get(),
+                ev_amps=int(_float_from_entry(self.house_entries["ev"]) or 32),
+            )
+            result = calculate_demand(dw)
+            self.house_result.set(
+                f"{result['amps']:.1f} A -> {result['suggested_breaker']} A"
+            )
+        except (ValueError, ValidationError) as err:
+            messagebox.showerror("Error", str(err))
+
+    # Duplex Tab
+    def _init_duplex_tab(self, notebook: ttk.Notebook) -> None:
+        frame = ttk.Frame(notebook)
+        notebook.add(frame, text="Duplex")
+
+        fields = [
+            ("Floor Area (m²)", "floor"),
+            ("Heating kW", "heat"),
+            ("AC kW", "ac"),
+            ("Range kW", "range"),
+            ("Dryer kW", "dryer"),
+            ("Water Heater kW", "wh"),
+        ]
+
+        self.duplex_entries: list[dict[str, ttk.Entry]] = []
+        for col in range(2):
+            lf = ttk.LabelFrame(frame, text=f"Unit {col + 1}")
+            lf.grid(row=0, column=col, padx=5, pady=5, sticky="n")
+            entries: dict[str, ttk.Entry] = {}
+            for row, (label, key) in enumerate(fields):
+                ttk.Label(lf, text=label).grid(row=row, column=0, sticky="w")
+                entry = ttk.Entry(lf)
+                entry.grid(row=row, column=1)
+                entries[key] = entry
+            self.duplex_entries.append(entries)
+
+        ttk.Button(frame, text="Calculate", command=self._calc_duplex).grid(
+            row=1, column=0, columnspan=2, pady=5
+        )
+
+        self.duplex_result = tk.StringVar()
+        ttk.Label(frame, textvariable=self.duplex_result).grid(
+            row=2, column=0, columnspan=2
+        )
+
+    def _make_unit(self, entries: dict[str, ttk.Entry]) -> Dwelling:
+        return Dwelling(
+            floor_area_m2=float(entries["floor"].get()),
+            heat_kw=pos_or_none(_float_from_entry(entries["heat"]), "heat_kw"),
+            ac_kw=pos_or_none(_float_from_entry(entries["ac"]), "ac_kw"),
+            range_kw=_float_from_entry(entries["range"]) or 12.0,
+            dryer_kw=pos_or_none(_float_from_entry(entries["dryer"]), "dryer_kw"),
+            water_heater_kw=pos_or_none(
+                _float_from_entry(entries["wh"]), "water_heater_kw"
+            ),
+        )
+
+    def _calc_duplex(self) -> None:
+        try:
+            a = self._make_unit(self.duplex_entries[0])
+            b = self._make_unit(self.duplex_entries[1])
+            result = calculate_duplex_demand(a, b)
+            self.duplex_result.set(
+                f"{result['amps']:.1f} A -> {result['suggested_breaker']} A"
+            )
+        except (ValueError, ValidationError) as err:
+            messagebox.showerror("Error", str(err))
+
+
+def main() -> None:
+    app = ServiceApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/BuildingServiceTools/cec_service/models.py
+++ b/BuildingServiceTools/cec_service/models.py
@@ -1,0 +1,17 @@
+"""Data models for CEC service calculations."""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(slots=True)
+class Dwelling:
+    """Representation of a dwelling unit."""
+
+    floor_area_m2: float
+    heat_kw: Optional[float]
+    ac_kw: Optional[float]
+    range_kw: float = 12.0
+    dryer_kw: Optional[float] = None
+    water_heater_kw: Optional[float] = None
+    has_ev: bool = False
+    ev_amps: int = 32

--- a/BuildingServiceTools/cec_service/utils/breakers.py
+++ b/BuildingServiceTools/cec_service/utils/breakers.py
@@ -1,0 +1,13 @@
+"""Breaker size selection utilities."""
+from bisect import bisect_left
+
+
+STANDARD_BREAKERS = [60, 100, 125, 150, 200, 225, 300, 400]
+
+
+def next_standard_breaker(amps: float) -> int:
+    """Return the next standard breaker size in amps."""
+    index = bisect_left(STANDARD_BREAKERS, int(round(amps)))
+    if index < len(STANDARD_BREAKERS):
+        return STANDARD_BREAKERS[index]
+    return int(amps + 1)  # round up for values above list

--- a/BuildingServiceTools/cec_service/utils/validation.py
+++ b/BuildingServiceTools/cec_service/utils/validation.py
@@ -1,0 +1,14 @@
+"""Validation helpers for input values."""
+
+
+class ValidationError(ValueError):
+    """Raised when validation fails."""
+
+
+def pos_or_none(val: float | None, field: str) -> float | None:
+    """Return value if positive or None; raise otherwise."""
+    if val is None:
+        return None
+    if val < 0:
+        raise ValidationError(f"{field} must be positive")
+    return val

--- a/BuildingServiceTools/pyproject.toml
+++ b/BuildingServiceTools/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "BuildingServiceTools"
+version = "0.1.0"
+requires-python = ">=3.10"
+description = "Tools for calculating CEC 2024 service loads"
+authors = [{name = "Unknown"}]
+
+[tool.black]
+line-length = 88
+
+[tool.mypy]
+python_version = "3.10"
+check_untyped_defs = true
+strict_optional = true


### PR DESCRIPTION
## Summary
- implement BuildingServiceTools package with service load calculators
- add Tkinter GUI to run the calculators
- provide project metadata in `pyproject.toml`
- document usage in README

## Testing
- `python -m py_compile $(find BuildingServiceTools -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_68488c3060788326a0cbf7fc07a2be4f