### PR TITLE
Fix GUI direct execution

### DIFF
--- a/BuildingServiceTools/cec_service/__init__.py
+++ b/BuildingServiceTools/cec_service/__init__.py
@@ -2,4 +2,7 @@
 from importlib import metadata
 
 __all__ = ["__version__"]
-__version__ = metadata.version("BuildingServiceTools")
+try:
+    __version__ = metadata.version("BuildingServiceTools")
+except metadata.PackageNotFoundError:  # pragma: no cover - fallback for local runs
+    __version__ = "0.0.0"

--- a/BuildingServiceTools/cec_service/gui/app.py
+++ b/BuildingServiceTools/cec_service/gui/app.py
@@ -1,13 +1,24 @@
 """Tkinter GUI application for service calculations."""
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 import tkinter as tk
 from tkinter import messagebox, ttk
 
-from ..calculators.duplex import calculate_duplex_demand
-from ..calculators.house import calculate_demand
-from ..models import Dwelling
-from ..utils.validation import ValidationError, pos_or_none
+# Allow running this file directly by adjusting sys.path for relative imports
+if __package__ in {None, ""}:
+    # When run directly, add the project root to sys.path so absolute imports work
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from cec_service.calculators.duplex import calculate_duplex_demand
+    from cec_service.calculators.house import calculate_demand
+    from cec_service.models import Dwelling
+    from cec_service.utils.validation import ValidationError, pos_or_none
+else:
+    from ..calculators.duplex import calculate_duplex_demand
+    from ..calculators.house import calculate_demand
+    from ..models import Dwelling
+    from ..utils.validation import ValidationError, pos_or_none
 
 
 def _float_from_entry(entry: ttk.Entry) -> float | None:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # CECServiceCalculator
 Electrical Service Calculator
+
+## Running the GUI
+
+From the project root run:
+
+```bash
+python -m cec_service.gui.app
+```
+
+Running the `app.py` file directly can cause import errors because it relies on
+package-relative imports. Invoking it as a module ensures Python sets up the
+package correctly.


### PR DESCRIPTION
## Summary
- allow running `app.py` directly by adjusting `sys.path`
- avoid metadata error when package isn't installed
- clarify GUI running instructions in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python BuildingServiceTools/cec_service/gui/app.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68488e46a3a083269166f62b7ba71b74