### PR TITLE
Add triplex support and PDF steps

### DIFF
--- a/BuildingServiceTools/README.md
+++ b/BuildingServiceTools/README.md
@@ -1,6 +1,6 @@
 # BuildingServiceTools
 
-This project provides tools for calculating Canadian Electrical Code (CEC) 2024 service-load requirements for residential buildings. It includes calculators for individual houses and duplexes with a simple graphical user interface.
+This project provides tools for calculating Canadian Electrical Code (CEC) 2024 service-load requirements for residential buildings. It includes calculators for individual houses, duplexes and triplexes with a simple graphical user interface.
 
 ## Requirements
 - Python 3.10 or newer

--- a/BuildingServiceTools/cec_service/__init__.py
+++ b/BuildingServiceTools/cec_service/__init__.py
@@ -2,4 +2,7 @@
 from importlib import metadata
 
 __all__ = ["__version__"]
-__version__ = metadata.version("BuildingServiceTools")
+try:
+    __version__ = metadata.version("BuildingServiceTools")
+except metadata.PackageNotFoundError:  # pragma: no cover - fallback for local runs
+    __version__ = "0.0.0"

--- a/BuildingServiceTools/cec_service/calculators/duplex.py
+++ b/BuildingServiceTools/cec_service/calculators/duplex.py
@@ -1,45 +1,65 @@
 """Duplex service load calculator."""
 from dataclasses import asdict
-from math import ceil
+from typing import Any, Dict, List, Tuple
 
 from ..models import Dwelling
 from ..utils.breakers import next_standard_breaker
+from .house import _unit_details
 
 
-def _unit_loads(dw: Dwelling) -> tuple[int, int]:
-    """Return tuple of (base_watts_without_heat_ac, heat_ac_watts)."""
-    basic_load = 5000
-    if dw.floor_area_m2 > 90:
-        extra_area = dw.floor_area_m2 - 90
-        basic_load += ceil(extra_area / 90) * 1000
-
-    range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
-    ev_load = dw.ev_amps * 240 if dw.has_ev else 0
-    dryer_load = int((dw.dryer_kw or 0) * 1000 * 0.25)
-    wh_load = int((dw.water_heater_kw or 0) * 1000 * 0.25)
-    heat_ac = max(dw.heat_kw or 0, dw.ac_kw or 0) * 1000
-
-    base = basic_load + range_load + ev_load + dryer_load + wh_load
-    return base, int(heat_ac)
+def _unit_loads(dw: Dwelling) -> Tuple[int, int, Dict[str, int], List[str]]:
+    """Wrapper around :func:`_unit_details` for duplex."""
+    return _unit_details(dw)
 
 
-def calculate_duplex_demand(a: Dwelling, b: Dwelling) -> dict:
+def calculate_duplex_demand(a: Dwelling, b: Dwelling) -> Dict[str, Any]:
     """Calculate service demand for a duplex."""
-    base_a, heat_a = _unit_loads(a)
-    base_b, heat_b = _unit_loads(b)
+    base_a, heat_a, det_a, steps_a = _unit_loads(a)
+    base_b, heat_b, det_b, steps_b = _unit_loads(b)
 
+    steps: List[str] = []
     if base_a >= base_b:
-        total = base_a + int(base_b * 0.65)
+        combined = base_a + int(base_b * 0.65)
+        combined_detail = {
+            "base_from_largest": base_a,
+            "0.65_of_smaller": int(base_b * 0.65),
+        }
+        steps.append(
+            f"Combined base: {base_a} + 65% of {base_b} = {combined} W"
+        )
     else:
-        total = base_b + int(base_a * 0.65)
+        combined = base_b + int(base_a * 0.65)
+        combined_detail = {
+            "base_from_largest": base_b,
+            "0.65_of_smaller": int(base_a * 0.65),
+        }
+        steps.append(
+            f"Combined base: {base_b} + 65% of {base_a} = {combined} W"
+        )
 
-    total += heat_a + heat_b
+    total = combined + heat_a + heat_b
+    steps.extend([
+        f"Unit A heat/AC: {heat_a} W",
+        f"Unit B heat/AC: {heat_b} W",
+        f"Total = {combined} + {heat_a} + {heat_b} = {total} W",
+    ])
     amps = total / 240
     breaker = next_standard_breaker(amps)
+
+    details = {
+        "unit_a": det_a,
+        "unit_b": det_b,
+        "combined_base": combined_detail,
+        "heat_a": heat_a,
+        "heat_b": heat_b,
+        "total_watts": total,
+    }
 
     return {
         "watts": total,
         "amps": amps,
         "suggested_breaker": breaker,
         "inputs": {"unit_a": asdict(a), "unit_b": asdict(b)},
+        "details": details,
+        "steps": steps_a + steps_b + steps,
     }

--- a/BuildingServiceTools/cec_service/calculators/house.py
+++ b/BuildingServiceTools/cec_service/calculators/house.py
@@ -1,25 +1,74 @@
 """House service load calculator."""
 from dataclasses import asdict
 from math import ceil
+from typing import Any, Dict, List, Tuple
 
 from ..models import Dwelling
 from ..utils.breakers import next_standard_breaker
 
 
-def calculate_demand(dw: Dwelling) -> dict:
-    """Calculate service demand for a single dwelling unit."""
+def _unit_details(dw: Dwelling) -> Tuple[int, int, Dict[str, int], List[str]]:
+    """Return base load, heat/AC watts, numeric details and explanation lines."""
+    details: Dict[str, int] = {}
+    steps: List[str] = []
+
     basic_load = 5000
+    details["basic_load"] = basic_load
+    steps.append("Basic load: 5000 W")
     if dw.floor_area_m2 > 90:
         extra_area = dw.floor_area_m2 - 90
-        basic_load += ceil(extra_area / 90) * 1000
+        blocks = ceil(extra_area / 90)
+        extra = blocks * 1000
+        basic_load += extra
+        details["extra_area_load"] = extra
+        steps.append(
+            f"Extra area {extra_area:.0f} m² -> {blocks} x 1000 W = {extra} W"
+        )
 
-    heat_ac = max(dw.heat_kw or 0, dw.ac_kw or 0) * 1000
     range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
-    ev_load = dw.ev_amps * 240 if dw.has_ev else 0
-    dryer_load = int((dw.dryer_kw or 0) * 1000 * 0.25)
-    wh_load = int((dw.water_heater_kw or 0) * 1000 * 0.25)
+    details["range_load"] = range_load
+    steps.append(f"Range: {dw.range_kw} kW -> {range_load} W")
 
-    total_watts = basic_load + heat_ac + range_load + ev_load + dryer_load + wh_load
+    ev_load = dw.ev_amps * 240 if dw.has_ev else 0
+    details["ev_load"] = ev_load
+    if dw.has_ev:
+        steps.append(f"EVSE: {dw.ev_amps} A x 240 V = {ev_load} W")
+    else:
+        steps.append("EVSE: not included")
+
+    dryer_kw = dw.dryer_kw or 0
+    dryer_load = int(dryer_kw * 1000 * 0.25)
+    details["dryer_load"] = dryer_load
+    steps.append(
+        f"Dryer: {dryer_kw * 1000:.0f} W x 25% = {dryer_load} W"
+    )
+
+    wh_kw = dw.water_heater_kw or 0
+    wh_load = int(wh_kw * 1000 * 0.25)
+    details["wh_load"] = wh_load
+    steps.append(
+        f"Water heater: {wh_kw * 1000:.0f} W x 25% = {wh_load} W"
+    )
+
+    heat_ac_kw = max(dw.heat_kw or 0, dw.ac_kw or 0)
+    heat_ac = int(heat_ac_kw * 1000)
+    details["heat_ac"] = heat_ac
+    steps.append(f"Heat/AC: {heat_ac_kw} kW x 1000 = {heat_ac} W")
+
+    base = basic_load + range_load + ev_load + dryer_load + wh_load
+    details["base_without_heat_ac"] = base
+    steps.append(f"Base without heat/AC: {base} W")
+
+    return base, heat_ac, details, steps
+
+
+def calculate_demand(dw: Dwelling) -> Dict[str, Any]:
+    """Calculate service demand for a single dwelling unit."""
+    base, heat_ac, details, steps = _unit_details(dw)
+
+    total_watts = base + heat_ac
+    details["total_watts"] = total_watts
+    steps.append(f"Total = {base} + {heat_ac} = {total_watts} W")
     amps = total_watts / 240
     breaker = next_standard_breaker(amps)
 
@@ -28,4 +77,6 @@ def calculate_demand(dw: Dwelling) -> dict:
         "amps": amps,
         "suggested_breaker": breaker,
         "inputs": asdict(dw),
+        "details": details,
+        "steps": steps,
     }

--- a/BuildingServiceTools/cec_service/calculators/triplex.py
+++ b/BuildingServiceTools/cec_service/calculators/triplex.py
@@ -1,0 +1,66 @@
+"""Triplex service load calculator."""
+from dataclasses import asdict
+from typing import Any, Dict, List, Tuple
+
+from ..models import Dwelling
+from ..utils.breakers import next_standard_breaker
+from .house import _unit_details
+
+
+def _unit_loads(dw: Dwelling) -> Tuple[int, int, Dict[str, int], List[str]]:
+    """Wrapper around :func:`_unit_details` for triplex."""
+    return _unit_details(dw)
+
+
+def calculate_triplex_demand(a: Dwelling, b: Dwelling, c: Dwelling) -> Dict[str, Any]:
+    """Calculate service demand for a triplex."""
+    base_a, heat_a, det_a, steps_a = _unit_loads(a)
+    base_b, heat_b, det_b, steps_b = _unit_loads(b)
+    base_c, heat_c, det_c, steps_c = _unit_loads(c)
+
+    bases: List[Tuple[str, int]] = [("A", base_a), ("B", base_b), ("C", base_c)]
+    bases.sort(key=lambda x: x[1], reverse=True)
+    largest_name, largest_base = bases[0]
+    mid_name, mid_base = bases[1]
+    small_name, small_base = bases[2]
+
+    combined = largest_base + int(mid_base * 0.65) + int(small_base * 0.65)
+    steps: List[str] = [
+        f"Combined base: {largest_name} {largest_base} + 65% of {mid_name} {mid_base} + 65% of {small_name} {small_base} = {combined} W"
+    ]
+
+    total = combined + heat_a + heat_b + heat_c
+    steps.extend(
+        [
+            f"Unit A heat/AC: {heat_a} W",
+            f"Unit B heat/AC: {heat_b} W",
+            f"Unit C heat/AC: {heat_c} W",
+            f"Total = {combined} + {heat_a} + {heat_b} + {heat_c} = {total} W",
+        ]
+    )
+    amps = total / 240
+    breaker = next_standard_breaker(amps)
+
+    details = {
+        "unit_a": det_a,
+        "unit_b": det_b,
+        "unit_c": det_c,
+        "combined_base": {
+            "largest": {largest_name: largest_base},
+            "0.65_of_mid": int(mid_base * 0.65),
+            "0.65_of_small": int(small_base * 0.65),
+        },
+        "heat_a": heat_a,
+        "heat_b": heat_b,
+        "heat_c": heat_c,
+        "total_watts": total,
+    }
+
+    return {
+        "watts": total,
+        "amps": amps,
+        "suggested_breaker": breaker,
+        "inputs": {"unit_a": asdict(a), "unit_b": asdict(b), "unit_c": asdict(c)},
+        "details": details,
+        "steps": steps_a + steps_b + steps_c + steps,
+    }

--- a/BuildingServiceTools/cec_service/gui/app.py
+++ b/BuildingServiceTools/cec_service/gui/app.py
@@ -1,13 +1,28 @@
 """Tkinter GUI application for service calculations."""
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 import tkinter as tk
-from tkinter import messagebox, ttk
+from tkinter import messagebox, ttk, filedialog
 
-from ..calculators.duplex import calculate_duplex_demand
-from ..calculators.house import calculate_demand
-from ..models import Dwelling
-from ..utils.validation import ValidationError, pos_or_none
+# Allow running this file directly by adjusting sys.path for relative imports
+if __package__ in {None, ""}:
+    # When run directly, add the project root to sys.path so absolute imports work
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from cec_service.calculators.duplex import calculate_duplex_demand
+    from cec_service.calculators.triplex import calculate_triplex_demand
+    from cec_service.calculators.house import calculate_demand
+    from cec_service.models import Dwelling
+    from cec_service.utils.validation import ValidationError, pos_or_none
+    from cec_service.utils.pdf import simple_pdf
+else:
+    from ..calculators.duplex import calculate_duplex_demand
+    from ..calculators.triplex import calculate_triplex_demand
+    from ..calculators.house import calculate_demand
+    from ..models import Dwelling
+    from ..utils.validation import ValidationError, pos_or_none
+    from ..utils.pdf import simple_pdf
 
 
 def _float_from_entry(entry: ttk.Entry) -> float | None:
@@ -26,6 +41,7 @@ class ServiceApp(tk.Tk):
 
         self._init_house_tab(notebook)
         self._init_duplex_tab(notebook)
+        self._init_triplex_tab(notebook)
 
     # House Tab
     def _init_house_tab(self, notebook: ttk.Notebook) -> None:
@@ -48,7 +64,7 @@ class ServiceApp(tk.Tk):
             entry.grid(row=row, column=1)
             self.house_entries[key] = entry
 
-        self.house_ev_var = tk.BooleanVar()
+        self.house_ev_var = tk.BooleanVar(value=True)
         ttk.Checkbutton(frame, text="Include EVSE", variable=self.house_ev_var).grid(
             row=len(labels), column=0, columnspan=2
         )
@@ -57,9 +73,13 @@ class ServiceApp(tk.Tk):
             row=len(labels) + 1, column=0, columnspan=2, pady=5
         )
 
+        ttk.Button(frame, text="Export PDF", command=self._export_house_pdf).grid(
+            row=len(labels) + 2, column=0, columnspan=2
+        )
+
         self.house_result = tk.StringVar()
         ttk.Label(frame, textvariable=self.house_result).grid(
-            row=len(labels) + 2, column=0, columnspan=2
+            row=len(labels) + 3, column=0, columnspan=2
         )
 
     def _calc_house(self) -> None:
@@ -81,9 +101,35 @@ class ServiceApp(tk.Tk):
                 ev_amps=int(_float_from_entry(self.house_entries["ev"]) or 32),
             )
             result = calculate_demand(dw)
+            self.house_last_result = result
             self.house_result.set(
                 f"{result['amps']:.1f} A -> {result['suggested_breaker']} A"
             )
+        except (ValueError, ValidationError) as err:
+            messagebox.showerror("Error", str(err))
+
+    def _export_house_pdf(self) -> None:
+        try:
+            if not hasattr(self, "house_last_result"):
+                self._calc_house()
+            result = self.house_last_result
+            if result is None:
+                return
+            path = filedialog.asksaveasfilename(
+                defaultextension=".pdf", filetypes=[("PDF", "*.pdf")]
+            )
+            if not path:
+                return
+            lines = [
+                "House Calculation",
+                f"Total Watts: {result['watts']}",
+                f"Total Amps: {result['amps']:.1f}",
+                f"Suggested Breaker: {result['suggested_breaker']} A",
+                "",
+                "Steps:",
+            ]
+            lines.extend(result["steps"])
+            simple_pdf(lines, path)
         except (ValueError, ValidationError) as err:
             messagebox.showerror("Error", str(err))
 
@@ -99,9 +145,11 @@ class ServiceApp(tk.Tk):
             ("Range kW", "range"),
             ("Dryer kW", "dryer"),
             ("Water Heater kW", "wh"),
+            ("EV Amps", "ev"),
         ]
 
         self.duplex_entries: list[dict[str, ttk.Entry]] = []
+        self.duplex_ev_vars: list[tk.BooleanVar] = []
         for col in range(2):
             lf = ttk.LabelFrame(frame, text=f"Unit {col + 1}")
             lf.grid(row=0, column=col, padx=5, pady=5, sticky="n")
@@ -111,18 +159,27 @@ class ServiceApp(tk.Tk):
                 entry = ttk.Entry(lf)
                 entry.grid(row=row, column=1)
                 entries[key] = entry
+            var = tk.BooleanVar(value=True)
+            ttk.Checkbutton(lf, text="Include EVSE", variable=var).grid(
+                row=len(fields), column=0, columnspan=2
+            )
+            self.duplex_ev_vars.append(var)
             self.duplex_entries.append(entries)
 
         ttk.Button(frame, text="Calculate", command=self._calc_duplex).grid(
             row=1, column=0, columnspan=2, pady=5
         )
 
-        self.duplex_result = tk.StringVar()
-        ttk.Label(frame, textvariable=self.duplex_result).grid(
+        ttk.Button(frame, text="Export PDF", command=self._export_duplex_pdf).grid(
             row=2, column=0, columnspan=2
         )
 
-    def _make_unit(self, entries: dict[str, ttk.Entry]) -> Dwelling:
+        self.duplex_result = tk.StringVar()
+        ttk.Label(frame, textvariable=self.duplex_result).grid(
+            row=3, column=0, columnspan=2
+        )
+
+    def _make_unit(self, entries: dict[str, ttk.Entry], idx: int) -> Dwelling:
         return Dwelling(
             floor_area_m2=float(entries["floor"].get()),
             heat_kw=pos_or_none(_float_from_entry(entries["heat"]), "heat_kw"),
@@ -132,16 +189,142 @@ class ServiceApp(tk.Tk):
             water_heater_kw=pos_or_none(
                 _float_from_entry(entries["wh"]), "water_heater_kw"
             ),
+            has_ev=self.duplex_ev_vars[idx].get(),
+            ev_amps=int(_float_from_entry(entries["ev"]) or 32),
         )
 
     def _calc_duplex(self) -> None:
         try:
-            a = self._make_unit(self.duplex_entries[0])
-            b = self._make_unit(self.duplex_entries[1])
+            a = self._make_unit(self.duplex_entries[0], 0)
+            b = self._make_unit(self.duplex_entries[1], 1)
             result = calculate_duplex_demand(a, b)
+            self.duplex_last_result = result
             self.duplex_result.set(
                 f"{result['amps']:.1f} A -> {result['suggested_breaker']} A"
             )
+        except (ValueError, ValidationError) as err:
+            messagebox.showerror("Error", str(err))
+
+    def _export_duplex_pdf(self) -> None:
+        try:
+            if not hasattr(self, "duplex_last_result"):
+                self._calc_duplex()
+            result = self.duplex_last_result
+            if result is None:
+                return
+            path = filedialog.asksaveasfilename(
+                defaultextension=".pdf", filetypes=[("PDF", "*.pdf")]
+            )
+            if not path:
+                return
+            lines = [
+                "Duplex Calculation",
+                f"Total Watts: {result['watts']}",
+                f"Total Amps: {result['amps']:.1f}",
+                f"Suggested Breaker: {result['suggested_breaker']} A",
+                "",
+                "Steps:",
+            ]
+            lines.extend(result["steps"])
+            simple_pdf(lines, path)
+        except (ValueError, ValidationError) as err:
+            messagebox.showerror("Error", str(err))
+
+    # Triplex Tab
+    def _init_triplex_tab(self, notebook: ttk.Notebook) -> None:
+        frame = ttk.Frame(notebook)
+        notebook.add(frame, text="Triplex")
+
+        fields = [
+            ("Floor Area (m²)", "floor"),
+            ("Heating kW", "heat"),
+            ("AC kW", "ac"),
+            ("Range kW", "range"),
+            ("Dryer kW", "dryer"),
+            ("Water Heater kW", "wh"),
+            ("EV Amps", "ev"),
+        ]
+
+        self.triplex_entries: list[dict[str, ttk.Entry]] = []
+        self.triplex_ev_vars: list[tk.BooleanVar] = []
+        for col in range(3):
+            lf = ttk.LabelFrame(frame, text=f"Unit {col + 1}")
+            lf.grid(row=0, column=col, padx=5, pady=5, sticky="n")
+            entries: dict[str, ttk.Entry] = {}
+            for row, (label, key) in enumerate(fields):
+                ttk.Label(lf, text=label).grid(row=row, column=0, sticky="w")
+                entry = ttk.Entry(lf)
+                entry.grid(row=row, column=1)
+                entries[key] = entry
+            var = tk.BooleanVar(value=True)
+            ttk.Checkbutton(lf, text="Include EVSE", variable=var).grid(
+                row=len(fields), column=0, columnspan=2
+            )
+            self.triplex_ev_vars.append(var)
+            self.triplex_entries.append(entries)
+
+        ttk.Button(frame, text="Calculate", command=self._calc_triplex).grid(
+            row=1, column=0, columnspan=3, pady=5
+        )
+
+        ttk.Button(frame, text="Export PDF", command=self._export_triplex_pdf).grid(
+            row=2, column=0, columnspan=3
+        )
+
+        self.triplex_result = tk.StringVar()
+        ttk.Label(frame, textvariable=self.triplex_result).grid(
+            row=3, column=0, columnspan=3
+        )
+
+    def _make_triplex_unit(self, entries: dict[str, ttk.Entry], idx: int) -> Dwelling:
+        return Dwelling(
+            floor_area_m2=float(entries["floor"].get()),
+            heat_kw=pos_or_none(_float_from_entry(entries["heat"]), "heat_kw"),
+            ac_kw=pos_or_none(_float_from_entry(entries["ac"]), "ac_kw"),
+            range_kw=_float_from_entry(entries["range"]) or 12.0,
+            dryer_kw=pos_or_none(_float_from_entry(entries["dryer"]), "dryer_kw"),
+            water_heater_kw=pos_or_none(
+                _float_from_entry(entries["wh"]), "water_heater_kw"
+            ),
+            has_ev=self.triplex_ev_vars[idx].get(),
+            ev_amps=int(_float_from_entry(entries["ev"]) or 32),
+        )
+
+    def _calc_triplex(self) -> None:
+        try:
+            a = self._make_triplex_unit(self.triplex_entries[0], 0)
+            b = self._make_triplex_unit(self.triplex_entries[1], 1)
+            c = self._make_triplex_unit(self.triplex_entries[2], 2)
+            result = calculate_triplex_demand(a, b, c)
+            self.triplex_last_result = result
+            self.triplex_result.set(
+                f"{result['amps']:.1f} A -> {result['suggested_breaker']} A"
+            )
+        except (ValueError, ValidationError) as err:
+            messagebox.showerror("Error", str(err))
+
+    def _export_triplex_pdf(self) -> None:
+        try:
+            if not hasattr(self, "triplex_last_result"):
+                self._calc_triplex()
+            result = self.triplex_last_result
+            if result is None:
+                return
+            path = filedialog.asksaveasfilename(
+                defaultextension=".pdf", filetypes=[("PDF", "*.pdf")]
+            )
+            if not path:
+                return
+            lines = [
+                "Triplex Calculation",
+                f"Total Watts: {result['watts']}",
+                f"Total Amps: {result['amps']:.1f}",
+                f"Suggested Breaker: {result['suggested_breaker']} A",
+                "",
+                "Steps:",
+            ]
+            lines.extend(result["steps"])
+            simple_pdf(lines, path)
         except (ValueError, ValidationError) as err:
             messagebox.showerror("Error", str(err))
 

--- a/BuildingServiceTools/cec_service/utils/pdf.py
+++ b/BuildingServiceTools/cec_service/utils/pdf.py
@@ -1,0 +1,47 @@
+"""Minimal PDF generation utilities."""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def _escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def simple_pdf(lines: Iterable[str], path: str) -> None:
+    """Write lines of text to *path* as a simple one-page PDF."""
+    escaped = [_escape(line) for line in lines]
+    stream_lines = ["BT", "/F1 12 Tf", "72 760 Td"]
+    for line in escaped:
+        stream_lines.append(f"({line}) Tj")
+        stream_lines.append("0 -14 Td")
+    stream_lines.append("ET")
+    stream = "\n".join(stream_lines)
+
+    objects: list[str] = []
+    offsets: list[int] = []
+
+    def add(obj: str) -> None:
+        offsets.append(len("%PDF-1.4\n") + sum(len(o) for o in objects))
+        objects.append(obj)
+
+    add("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    add("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+    add(
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> "
+        "/MediaBox [0 0 612 792] /Contents 5 0 R >>\nendobj\n"
+    )
+    add("4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Courier >>\nendobj\n")
+    add(f"5 0 obj\n<< /Length {len(stream)} >>\nstream\n{stream}\nendstream\nendobj\n")
+
+    xref_pos = len("%PDF-1.4\n") + sum(len(o) for o in objects)
+    xref_entries = ["0000000000 65535 f "] + [f"{o:010} 00000 n " for o in offsets]
+    xref = "xref\n0 6\n" + "\n".join(xref_entries) + "\n"
+    trailer = f"trailer\n<< /Root 1 0 R /Size 6 >>\nstartxref\n{xref_pos}\n%%EOF\n"
+
+    with open(path, "wb") as fh:
+        fh.write("%PDF-1.4\n".encode("ascii"))
+        for obj in objects:
+            fh.write(obj.encode("ascii"))
+        fh.write(xref.encode("ascii"))
+        fh.write(trailer.encode("ascii"))

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # CECServiceCalculator
-Electrical Service Calculator
+Electrical Service Calculator supporting single units, duplexes and triplexes.
+
+## Running the GUI
+
+From the project root run:
+
+```bash
+python -m cec_service.gui.app
+```
+
+Running the `app.py` file directly can cause import errors because it relies on
+package-relative imports. Invoking it as a module ensures Python sets up the
+package correctly.


### PR DESCRIPTION
## Summary
- default EVSE options to checked
- add detailed step explanations in calculators
- allow exporting step-by-step results to PDF without code listings
- support triplex calculations in GUI and backend
- update documentation for triplex support

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68488e46a3a083269166f62b7ba71b74