### PR TITLE
Add triplex calc and improve PDFs

### DIFF
--- a/BuildingServiceTools/cec_service/calculators/triplex.py
+++ b/BuildingServiceTools/cec_service/calculators/triplex.py
@@ -1,0 +1,74 @@
+"""Triplex service load calculator."""
+
+from dataclasses import asdict
+from math import ceil
+from typing import Any, Dict, Tuple
+
+from ..models import Dwelling
+from ..utils.breakers import next_standard_breaker
+
+
+def _unit_loads(dw: Dwelling) -> Tuple[int, int, Dict[str, int]]:
+    """Return tuple of (base_watts_without_heat_ac, heat_ac_watts, details)."""
+    details: Dict[str, int] = {}
+
+    basic_load = 5000
+    details["basic_load"] = basic_load
+    if dw.floor_area_m2 > 90:
+        extra_area = dw.floor_area_m2 - 90
+        extra = ceil(extra_area / 90) * 1000
+        basic_load += extra
+        details["extra_area_load"] = extra
+
+    range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
+    details["range_load"] = range_load
+    ev_load = dw.ev_amps * 240 if dw.has_ev else 0
+    details["ev_load"] = ev_load
+    dryer_load = int((dw.dryer_kw or 0) * 1000 * 0.25)
+    details["dryer_load"] = dryer_load
+    wh_load = int((dw.water_heater_kw or 0) * 1000 * 0.25)
+    details["wh_load"] = wh_load
+    heat_ac = int(max(dw.heat_kw or 0, dw.ac_kw or 0) * 1000)
+    details["heat_ac"] = heat_ac
+
+    base = basic_load + range_load + ev_load + dryer_load + wh_load
+    details["base_without_heat_ac"] = base
+    return base, heat_ac, details
+
+
+def calculate_triplex_demand(a: Dwelling, b: Dwelling, c: Dwelling) -> Dict[str, Any]:
+    """Calculate service demand for a triplex."""
+    units = [a, b, c]
+    loads = [_unit_loads(u) for u in units]
+    bases = [b for b, _h, _d in loads]
+
+    # Largest base taken at 100%, others at 65%
+    sorted_indices = sorted(range(3), key=lambda i: bases[i], reverse=True)
+    largest_idx = sorted_indices[0]
+    combined = bases[largest_idx]
+    combined_detail = {"base_from_largest": bases[largest_idx]}
+    for idx in sorted_indices[1:]:
+        combined += int(bases[idx] * 0.65)
+        combined_detail[f"0.65_of_unit_{idx + 1}"] = int(bases[idx] * 0.65)
+
+    total_heat = sum(load[1] for load in loads)
+    total_watts = combined + total_heat
+    amps = total_watts / 240
+    breaker = next_standard_breaker(amps)
+
+    details = {
+        "unit_a": loads[0][2],
+        "unit_b": loads[1][2],
+        "unit_c": loads[2][2],
+        "combined_base": combined_detail,
+        "total_heat": total_heat,
+        "total_watts": total_watts,
+    }
+
+    return {
+        "watts": total_watts,
+        "amps": amps,
+        "suggested_breaker": breaker,
+        "inputs": {"unit_a": asdict(a), "unit_b": asdict(b), "unit_c": asdict(c)},
+        "details": details,
+    }

--- a/BuildingServiceTools/cec_service/gui/app.py
+++ b/BuildingServiceTools/cec_service/gui/app.py
@@ -1,10 +1,13 @@
 """Tkinter GUI application for service calculations."""
+
 from __future__ import annotations
 
 import sys
 from pathlib import Path
 import tkinter as tk
 from tkinter import messagebox, ttk, filedialog
+from math import ceil
+from typing import Any
 
 # Allow running this file directly by adjusting sys.path for relative imports
 if __package__ in {None, ""}:
@@ -12,12 +15,14 @@ if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parents[2]))
     from cec_service.calculators.duplex import calculate_duplex_demand
     from cec_service.calculators.house import calculate_demand
+    from cec_service.calculators.triplex import calculate_triplex_demand
     from cec_service.models import Dwelling
     from cec_service.utils.validation import ValidationError, pos_or_none
     from cec_service.utils.pdf import simple_pdf
 else:
     from ..calculators.duplex import calculate_duplex_demand
     from ..calculators.house import calculate_demand
+    from ..calculators.triplex import calculate_triplex_demand
     from ..models import Dwelling
     from ..utils.validation import ValidationError, pos_or_none
     from ..utils.pdf import simple_pdf
@@ -26,6 +31,35 @@ else:
 def _float_from_entry(entry: ttk.Entry) -> float | None:
     text = entry.get().strip()
     return float(text) if text else None
+
+
+def _describe_unit(inputs: dict[str, Any], details: dict[str, int]) -> list[str]:
+    """Return human readable detail lines for a unit."""
+    lines: list[str] = []
+    floor = inputs["floor_area_m2"]
+    lines.append("Base load: 5000 W")
+    if "extra_area_load" in details:
+        extra_area = floor - 90
+        units = ceil(extra_area / 90)
+        lines.append(
+            f"Extra area: ({extra_area:.0f} m² /90 -> {units}) x 1000 W = {details['extra_area_load']} W"
+        )
+    lines.append(f"Range: {inputs['range_kw']} kW -> {details['range_load']} W")
+    if inputs.get("has_ev"):
+        lines.append(f"EVSE: {inputs['ev_amps']} A x 240 V = {details['ev_load']} W")
+    if inputs.get("dryer_kw"):
+        lines.append(
+            f"Dryer: {inputs['dryer_kw']} kW x 25% = {details['dryer_load']} W"
+        )
+    if inputs.get("water_heater_kw"):
+        lines.append(
+            f"Water Heater: {inputs['water_heater_kw']} kW x 25% = {details['wh_load']} W"
+        )
+    lines.append(
+        f"Heat/AC: max({inputs.get('heat_kw') or 0}, {inputs.get('ac_kw') or 0}) kW x 1000 = {details['heat_ac']} W"
+    )
+    lines.append(f"Total Watts: {details.get('total_watts', '?')}")
+    return lines
 
 
 class ServiceApp(tk.Tk):
@@ -39,6 +73,7 @@ class ServiceApp(tk.Tk):
 
         self._init_house_tab(notebook)
         self._init_duplex_tab(notebook)
+        self._init_triplex_tab(notebook)
 
     # House Tab
     def _init_house_tab(self, notebook: ttk.Notebook) -> None:
@@ -61,7 +96,7 @@ class ServiceApp(tk.Tk):
             entry.grid(row=row, column=1)
             self.house_entries[key] = entry
 
-        self.house_ev_var = tk.BooleanVar()
+        self.house_ev_var = tk.BooleanVar(value=True)
         ttk.Checkbutton(frame, text="Include EVSE", variable=self.house_ev_var).grid(
             row=len(labels), column=0, columnspan=2
         )
@@ -117,9 +152,6 @@ class ServiceApp(tk.Tk):
             )
             if not path:
                 return
-            import inspect
-
-            code = inspect.getsource(calculate_demand).splitlines()
             lines = [
                 "House Calculation",
                 f"Total Watts: {result['watts']}",
@@ -128,10 +160,7 @@ class ServiceApp(tk.Tk):
                 "",
                 "Details:",
             ]
-            for k, v in result["details"].items():
-                lines.append(f"{k}: {v}")
-            lines.extend(["", "Source:"])
-            lines.extend(f"{i+1}: {line}" for i, line in enumerate(code))
+            lines.extend(_describe_unit(result["inputs"], result["details"]))
             simple_pdf(lines, path)
         except (ValueError, ValidationError) as err:
             messagebox.showerror("Error", str(err))
@@ -162,7 +191,7 @@ class ServiceApp(tk.Tk):
                 entry = ttk.Entry(lf)
                 entry.grid(row=row, column=1)
                 entries[key] = entry
-            var = tk.BooleanVar()
+            var = tk.BooleanVar(value=True)
             ttk.Checkbutton(lf, text="Include EVSE", variable=var).grid(
                 row=len(fields), column=0, columnspan=2
             )
@@ -220,9 +249,6 @@ class ServiceApp(tk.Tk):
             )
             if not path:
                 return
-            import inspect
-
-            code = inspect.getsource(calculate_duplex_demand).splitlines()
             lines = [
                 "Duplex Calculation",
                 f"Total Watts: {result['watts']}",
@@ -231,15 +257,147 @@ class ServiceApp(tk.Tk):
                 "",
                 "Details:",
             ]
-            for section, det in result["details"].items():
-                if isinstance(det, dict):
-                    lines.append(section + ":")
-                    for k, v in det.items():
-                        lines.append(f"  {k}: {v}")
-                else:
-                    lines.append(f"{section}: {det}")
-            lines.extend(["", "Source:"])
-            lines.extend(f"{i+1}: {line}" for i, line in enumerate(code))
+            lines.append("Unit 1:")
+            lines.extend(
+                "  " + s
+                for s in _describe_unit(
+                    result["inputs"]["unit_a"], result["details"]["unit_a"]
+                )
+            )
+            lines.append("Unit 2:")
+            lines.extend(
+                "  " + s
+                for s in _describe_unit(
+                    result["inputs"]["unit_b"], result["details"]["unit_b"]
+                )
+            )
+            lines.append("Combined base:")
+            for k, v in result["details"]["combined_base"].items():
+                lines.append(f"  {k}: {v}")
+            lines.append(f"Heat unit 1: {result['details']['heat_a']} W")
+            lines.append(f"Heat unit 2: {result['details']['heat_b']} W")
+            simple_pdf(lines, path)
+        except (ValueError, ValidationError) as err:
+            messagebox.showerror("Error", str(err))
+
+    # Triplex Tab
+    def _init_triplex_tab(self, notebook: ttk.Notebook) -> None:
+        frame = ttk.Frame(notebook)
+        notebook.add(frame, text="Triplex")
+
+        fields = [
+            ("Floor Area (m²)", "floor"),
+            ("Heating kW", "heat"),
+            ("AC kW", "ac"),
+            ("Range kW", "range"),
+            ("Dryer kW", "dryer"),
+            ("Water Heater kW", "wh"),
+            ("EV Amps", "ev"),
+        ]
+
+        self.triplex_entries: list[dict[str, ttk.Entry]] = []
+        self.triplex_ev_vars: list[tk.BooleanVar] = []
+        for col in range(3):
+            lf = ttk.LabelFrame(frame, text=f"Unit {col + 1}")
+            lf.grid(row=0, column=col, padx=5, pady=5, sticky="n")
+            entries: dict[str, ttk.Entry] = {}
+            for row, (label, key) in enumerate(fields):
+                ttk.Label(lf, text=label).grid(row=row, column=0, sticky="w")
+                entry = ttk.Entry(lf)
+                entry.grid(row=row, column=1)
+                entries[key] = entry
+            var = tk.BooleanVar(value=True)
+            ttk.Checkbutton(lf, text="Include EVSE", variable=var).grid(
+                row=len(fields), column=0, columnspan=2
+            )
+            self.triplex_ev_vars.append(var)
+            self.triplex_entries.append(entries)
+
+        ttk.Button(frame, text="Calculate", command=self._calc_triplex).grid(
+            row=1, column=0, columnspan=3, pady=5
+        )
+
+        ttk.Button(frame, text="Export PDF", command=self._export_triplex_pdf).grid(
+            row=2, column=0, columnspan=3
+        )
+
+        self.triplex_result = tk.StringVar()
+        ttk.Label(frame, textvariable=self.triplex_result).grid(
+            row=3, column=0, columnspan=3
+        )
+
+    def _make_triplex_unit(self, entries: dict[str, ttk.Entry], idx: int) -> Dwelling:
+        return Dwelling(
+            floor_area_m2=float(entries["floor"].get()),
+            heat_kw=pos_or_none(_float_from_entry(entries["heat"]), "heat_kw"),
+            ac_kw=pos_or_none(_float_from_entry(entries["ac"]), "ac_kw"),
+            range_kw=_float_from_entry(entries["range"]) or 12.0,
+            dryer_kw=pos_or_none(_float_from_entry(entries["dryer"]), "dryer_kw"),
+            water_heater_kw=pos_or_none(
+                _float_from_entry(entries["wh"]), "water_heater_kw"
+            ),
+            has_ev=self.triplex_ev_vars[idx].get(),
+            ev_amps=int(_float_from_entry(entries["ev"]) or 32),
+        )
+
+    def _calc_triplex(self) -> None:
+        try:
+            a = self._make_triplex_unit(self.triplex_entries[0], 0)
+            b = self._make_triplex_unit(self.triplex_entries[1], 1)
+            c = self._make_triplex_unit(self.triplex_entries[2], 2)
+            result = calculate_triplex_demand(a, b, c)
+            self.triplex_last_result = result
+            self.triplex_result.set(
+                f"{result['amps']:.1f} A -> {result['suggested_breaker']} A"
+            )
+        except (ValueError, ValidationError) as err:
+            messagebox.showerror("Error", str(err))
+
+    def _export_triplex_pdf(self) -> None:
+        try:
+            if not hasattr(self, "triplex_last_result"):
+                self._calc_triplex()
+            result = self.triplex_last_result
+            if result is None:
+                return
+            path = filedialog.asksaveasfilename(
+                defaultextension=".pdf", filetypes=[("PDF", "*.pdf")]
+            )
+            if not path:
+                return
+            lines = [
+                "Triplex Calculation",
+                f"Total Watts: {result['watts']}",
+                f"Total Amps: {result['amps']:.1f}",
+                f"Suggested Breaker: {result['suggested_breaker']} A",
+                "",
+                "Details:",
+                "Unit 1:",
+            ]
+            lines.extend(
+                "  " + s
+                for s in _describe_unit(
+                    result["inputs"]["unit_a"], result["details"]["unit_a"]
+                )
+            )
+            lines.append("Unit 2:")
+            lines.extend(
+                "  " + s
+                for s in _describe_unit(
+                    result["inputs"]["unit_b"], result["details"]["unit_b"]
+                )
+            )
+            lines.append("Unit 3:")
+            lines.extend(
+                "  " + s
+                for s in _describe_unit(
+                    result["inputs"]["unit_c"], result["details"]["unit_c"]
+                )
+            )
+            lines.append("Combined base:")
+            for k, v in result["details"]["combined_base"].items():
+                lines.append(f"  {k}: {v}")
+            lines.append(f"Total heat: {result['details']['total_heat']} W")
             simple_pdf(lines, path)
         except (ValueError, ValidationError) as err:
             messagebox.showerror("Error", str(err))


### PR DESCRIPTION
## Summary
- default EVSE checkboxes to checked
- support triplex service calculation
- explain calculation details in exported PDFs and remove source block

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check BuildingServiceTools/cec_service/gui/app.py BuildingServiceTools/cec_service/calculators/triplex.py`


------
https://chatgpt.com/codex/tasks/task_e_6848c23142908326999eaffb2b013b57