### PR TITLE
Add range toggle and extra load options

### DIFF
--- a/BuildingServiceTools/cec_service/calculators/duplex.py
+++ b/BuildingServiceTools/cec_service/calculators/duplex.py
@@ -20,7 +20,9 @@ def _unit_loads(dw: Dwelling) -> Tuple[int, int, Dict[str, int]]:
         basic_load += extra
         details["extra_area_load"] = extra
 
-    range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
+    range_load = 0
+    if dw.has_range:
+        range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
     details["range_load"] = range_load
     ev_load = dw.ev_amps * 240 if dw.has_ev else 0
     details["ev_load"] = ev_load
@@ -28,10 +30,14 @@ def _unit_loads(dw: Dwelling) -> Tuple[int, int, Dict[str, int]]:
     details["dryer_load"] = dryer_load
     wh_load = int((dw.water_heater_kw or 0) * 1000 * 0.25)
     details["wh_load"] = wh_load
+    extra_load = 0
+    if dw.extra_loads:
+        extra_load = int(sum(kW for _lbl, kW in dw.extra_loads) * 1000 * 0.25)
+    details["extra_load"] = extra_load
     heat_ac = int(max(dw.heat_kw or 0, dw.ac_kw or 0) * 1000)
     details["heat_ac"] = heat_ac
 
-    base = basic_load + range_load + ev_load + dryer_load + wh_load
+    base = basic_load + range_load + ev_load + dryer_load + wh_load + extra_load
     details["base_without_heat_ac"] = base
     details["total_watts"] = base + heat_ac
     return base, heat_ac, details

--- a/BuildingServiceTools/cec_service/calculators/house.py
+++ b/BuildingServiceTools/cec_service/calculators/house.py
@@ -21,7 +21,9 @@ def calculate_demand(dw: Dwelling) -> Dict[str, Any]:
 
     heat_ac = int(max(dw.heat_kw or 0, dw.ac_kw or 0) * 1000)
     details["heat_ac"] = heat_ac
-    range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
+    range_load = 0
+    if dw.has_range:
+        range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
     details["range_load"] = range_load
     ev_load = dw.ev_amps * 240 if dw.has_ev else 0
     details["ev_load"] = ev_load
@@ -29,8 +31,20 @@ def calculate_demand(dw: Dwelling) -> Dict[str, Any]:
     details["dryer_load"] = dryer_load
     wh_load = int((dw.water_heater_kw or 0) * 1000 * 0.25)
     details["wh_load"] = wh_load
+    extra_load = 0
+    if dw.extra_loads:
+        extra_load = int(sum(kW for _lbl, kW in dw.extra_loads) * 1000 * 0.25)
+    details["extra_load"] = extra_load
 
-    total_watts = basic_load + heat_ac + range_load + ev_load + dryer_load + wh_load
+    total_watts = (
+        basic_load
+        + heat_ac
+        + range_load
+        + ev_load
+        + dryer_load
+        + wh_load
+        + extra_load
+    )
     details["total_watts"] = total_watts
     amps = total_watts / 240
     breaker = next_standard_breaker(amps)

--- a/BuildingServiceTools/cec_service/calculators/triplex.py
+++ b/BuildingServiceTools/cec_service/calculators/triplex.py
@@ -20,7 +20,9 @@ def _unit_loads(dw: Dwelling) -> Tuple[int, int, Dict[str, int]]:
         basic_load += extra
         details["extra_area_load"] = extra
 
-    range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
+    range_load = 0
+    if dw.has_range:
+        range_load = 6000 if dw.range_kw <= 12 else int(dw.range_kw * 1000)
     details["range_load"] = range_load
     ev_load = dw.ev_amps * 240 if dw.has_ev else 0
     details["ev_load"] = ev_load
@@ -28,10 +30,14 @@ def _unit_loads(dw: Dwelling) -> Tuple[int, int, Dict[str, int]]:
     details["dryer_load"] = dryer_load
     wh_load = int((dw.water_heater_kw or 0) * 1000 * 0.25)
     details["wh_load"] = wh_load
+    extra_load = 0
+    if dw.extra_loads:
+        extra_load = int(sum(kW for _lbl, kW in dw.extra_loads) * 1000 * 0.25)
+    details["extra_load"] = extra_load
     heat_ac = int(max(dw.heat_kw or 0, dw.ac_kw or 0) * 1000)
     details["heat_ac"] = heat_ac
 
-    base = basic_load + range_load + ev_load + dryer_load + wh_load
+    base = basic_load + range_load + ev_load + dryer_load + wh_load + extra_load
     details["base_without_heat_ac"] = base
     details["total_watts"] = base + heat_ac
     return base, heat_ac, details

--- a/BuildingServiceTools/cec_service/models.py
+++ b/BuildingServiceTools/cec_service/models.py
@@ -11,7 +11,10 @@ class Dwelling:
     heat_kw: Optional[float]
     ac_kw: Optional[float]
     range_kw: float = 12.0
+    has_range: bool = True
     dryer_kw: Optional[float] = None
     water_heater_kw: Optional[float] = None
+    # List of (label, kW) for other appliances >1.5kW
+    extra_loads: Optional[list[tuple[str, float]]] = None
     has_ev: bool = False
     ev_amps: int = 32


### PR DESCRIPTION
## Summary
- allow toggling whether a range is present
- support additional loads above 1.5 kW with labels
- expose range option in triplex units

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a4e53e46c8326a9ef0b4b00b78544