### PR TITLE
Add dryer and water heater dropdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ package correctly.
 The GUI allows specifying heating loads in either **kW** or **tons** when the
 HVAC type is set to *Heat Pump*. Residential heat pump sizes typically range
 from 1–5 tons (approximately 3.5–17.5&nbsp;kW).
+
+Dryer loads can be selected from common kW ratings, while water heater capacity
+may now be entered in **kW** or by choosing a standard tank size in gallons.


### PR DESCRIPTION
## Summary
- add constants for dryer and water heater dropdowns
- enable dropdowns for dryer kW and water heater gallon units across all tabs
- convert gallon selections to kW when calculating
- document new options

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b05655b38832680c66af6d3d25081